### PR TITLE
Fix incorrect mailbox count in report if AzureADGroup specified

### DIFF
--- a/Get-RubrikM365SizingInfo.ps1
+++ b/Get-RubrikM365SizingInfo.ps1
@@ -175,8 +175,14 @@ function ProcessUsageReport {
         Default { 
             if ($Section -eq "Exchange") {
                 
-                $TotalUserMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'User' }
-                $TotalSharedMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'Shared' }
+                if ($AzureAdRequired) {
+                    $TotalUserMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'User' -and $_.$FilterByField -in $AzureAdGroupMembersByUserPrincipalName }
+                    $TotalSharedMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'Shared' -and $_.$FilterByField -in $AzureAdGroupMembersByUserPrincipalName }
+                }
+                else {
+                    $TotalUserMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'User' }
+                    $TotalSharedMailbox = $ReportDetail | Where-Object { $_.'Recipient Type' -eq 'Shared' }
+                }
 
                 if ($TotalSharedMailbox.Count -ge $TotalUserMailbox.Count) {
                     # Total number of Shared Mailboxes is > than User mailboxes so we need to


### PR DESCRIPTION
The mailbox count still shows total count in the entire org even if we specify a specific AzureADGroup when running the script.

Before the fix:
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/23a0d064-5e57-4ab8-bd26-e5032ff03698)
After the fix:
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/a6b5512d-ec77-4794-9129-25e6deb79215)
Run on a different group:
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/66f1dd35-3f65-4eaa-b6d6-5d38132e0aec)