### PR TITLE
Remove folder scope restricted to archive folder for archive mailbox

### DIFF
--- a/Get-RubrikM365SizingInfo.ps1
+++ b/Get-RubrikM365SizingInfo.ps1
@@ -466,7 +466,7 @@ if ($SkipArchiveMailbox -eq $false) {
         # Process the first N number of Archive Mailboxes. Where N = $FirstInterval
         $ArchiveMailboxesFirstInverval = $ArchiveMailboxes | Select-Object -First $FirstInterval
         if ($ArchiveMailboxesCount -le $LargeAmountofArchiveMailboxCount) {
-            $ArchiveMailboxesFolders += $ArchiveMailboxesFirstInverval | Get-EXOMailboxFolderStatistics -Archive -Folderscope "Archive" | Select-Object name, FolderAndSubfolderSize
+            $ArchiveMailboxesFolders += $ArchiveMailboxesFirstInverval | Get-EXOMailboxFolderStatistics -Archive | Select-Object name, FolderAndSubfolderSize
 
         }
         else {
@@ -475,7 +475,7 @@ if ($SkipArchiveMailbox -eq $false) {
             Write-Output $ActionRequiredLogMessage
             Write-Output ""
             $ManualUserPrincipalName = Read-Host -Prompt $ActionRequiredPromptMessage
-            $ArchiveMailboxesFolders += Start-RobustCloudCommand -UserPrincipalName $ManualUserPrincipalName -IdentifyingProperty "DisplayName" -recipients $ArchiveMailboxesFirstInverval -logfile "$systemTempFolder\archiveMailbox.log" -ScriptBlock { Get-EXOMailboxFolderStatistics -Identity $input.UserPrincipalName -Archive -Folderscope "Archive" | Select-Object name, FolderAndSubfolderSize }     
+            $ArchiveMailboxesFolders += Start-RobustCloudCommand -UserPrincipalName $ManualUserPrincipalName -IdentifyingProperty "DisplayName" -recipients $ArchiveMailboxesFirstInverval -logfile "$systemTempFolder\archiveMailbox.log" -ScriptBlock { Get-EXOMailboxFolderStatistics -Identity $input.UserPrincipalName -Archive | Select-Object name, FolderAndSubfolderSize }     
             Write-Output ""
         
         }
@@ -488,10 +488,10 @@ if ($SkipArchiveMailbox -eq $false) {
                 $ArchiveMailboxesSecondaryInverval = $ArchiveMailboxes | Select-Object -Skip $SkipInternval -First $FirstInterval 
 
                 if ($ArchiveMailboxesCount -le $LargeAmountofArchiveMailboxCount) {
-                    $ArchiveMailboxesFolders += $ArchiveMailboxesSecondaryInverval | Get-EXOMailboxFolderStatistics -Archive -Folderscope "Archive" | Select-Object name, FolderAndSubfolderSize
+                    $ArchiveMailboxesFolders += $ArchiveMailboxesSecondaryInverval | Get-EXOMailboxFolderStatistics -Archive | Select-Object name, FolderAndSubfolderSize
                 }
                 else {
-                    $ArchiveMailboxesFolders += Start-RobustCloudCommand -UserPrincipalName $ManualUserPrincipalName -IdentifyingProperty "DisplayName" -recipients $ArchiveMailboxesSecondaryInverval -logfile "$systemTempFolder\archiveMailbox.log" -ScriptBlock { Get-EXOMailboxFolderStatistics -Identity $input.UserPrincipalName -Archive -Folderscope "Archive" | Select-Object name, FolderAndSubfolderSize }     
+                    $ArchiveMailboxesFolders += Start-RobustCloudCommand -UserPrincipalName $ManualUserPrincipalName -IdentifyingProperty "DisplayName" -recipients $ArchiveMailboxesSecondaryInverval -logfile "$systemTempFolder\archiveMailbox.log" -ScriptBlock { Get-EXOMailboxFolderStatistics -Identity $input.UserPrincipalName -Archive | Select-Object name, FolderAndSubfolderSize }     
                     Write-Output ""
                 }
                 $SkipInternval = $SkipInternval + $FirstInterval
@@ -509,8 +509,12 @@ if ($SkipArchiveMailbox -eq $false) {
 
             $ArchiveMailboxSizeGb += $FolderSizeInGb
         }
+        # Divided by two because the listed folders contain Top of Information Store which shows overall size of all the folders in side the mailbox.
+        $ArchiveMailboxSizeGb = $ArchiveMailboxSizeGb / 2
 
         $M365Sizing.Exchange.TotalSizeGB += $ArchiveMailboxSizeGb
+        $M365Sizing.Exchange.SizePerUserGB = [math]::Round(($M365Sizing.Exchange.TotalSizeGB / $M365Sizing.Exchange.NumberOfUsers), 2)
+        
     }
     catch {
         $errorException = $_.Exception

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ To filter OneDrive and Exchange results to a specific subset of users in an Azur
 The majority of the information collected is directly from the Microsoft 365 [Usage reports](https://docs.microsoft.com/en-us/microsoft-365/admin/activity-reports/activity-reports?view=o365-worldwide) that are found in the admin center.
 The benefit of this approach is that the information can be pulled in bulk and does not require a complete crawl of your Microsoft 365 subscription.
 
-The only downside of this approach is that the Usage reports do not contain any In-Place archive information. To gather that information Rubrik will request a separate set of permissions to pull statistics for each In-Place archive in your environment. Depending on the size of you environment, this can take a significant amount of time.  
-
 ## Example Output
 
 ![image](https://user-images.githubusercontent.com/51362633/190453033-94379a84-8678-4592-9d9b-2b1dad96a521.png)


### PR DESCRIPTION
### Problem
Currently, the script fetches folder size of the archive mailbox, but is only restricted to the Archive folder inside the mailbox. Thus the report would only contain size data from the Archive folder only.

### Method
This change removes the folder scope parameter where we specify and only get size of the Archive folder. We also make sure we update both the total size and size per user after we fetch the info.

### Test
For a mailbox which
- Primary mailbox has size 150Mb
- Archive mailbox has size 20Mb (Archive folder has size 2Mb)
```
PS /Users/ningshanli/Desktop/microsoft-365-sizing> Get-EXOMailboxStatistics -Identity ningshan.li@rdnn14.onmicrosoft.com                                                                                                    
DisplayName          : Ningshan Li
MailboxGuid          : 2bf597b0-bbb4-489e-bed7-a4aa9621720f
DeletedItemCount     : 1485
ItemCount            : 4108
TotalDeletedItemSize : 7.642 MB (8,012,985 bytes)
TotalItemSize        : 150.5 MB (157,771,552 bytes)

PS /Users/ningshanli/Desktop/microsoft-365-sizing> Get-EXOMailboxStatistics -Identity ningshan.li@rdnn14.onmicrosoft.com -Archive

DisplayName          : In-Place Archive -Ningshan Li
MailboxGuid          : 6721d77e-abef-4fdf-a844-cdcb9051a1ac
DeletedItemCount     : 8
ItemCount            : 26
TotalDeletedItemSize : 48.74 KB (49,907 bytes)
TotalItemSize        : 20.39 MB (21,381,129 bytes)

PS /Users/ningshanli/Desktop/microsoft-365-sizing> Get-EXOMailboxFolderStatistics -Identity ningshan.li@rdnn14.onmicrosoft.com -Archive -Folderscope “Archive” | Select-Object name, FolderAndSubfolderSize                 

Name    FolderAndSubfolderSize
----    ----------------------
Archive 2.071 MB (2,171,515 bytes)
```
Before the change:
- The result only contains primary mailbox size, and the Archive folder size
- The per user size data only contains primary mailbox size
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/6b619ada-c9eb-4bd7-b8ab-f776c82a5edf)

After the change:
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/0de2b868-2f19-46ca-a2af-3512ae0c3aee)
On another Azure group containing archive mailbox:
![image](https://github.com/rubrikinc/microsoft-365-sizing/assets/88054638/680a705a-b9a1-4328-ad1a-b60ac8839135)
