### PR TITLE
Add script to use app registration instead of user access

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 * `PowerShell >= 5.1` for PowerShell Gallery.
 * Microsoft user permissions to run this script: Global Reader and Reports Reader
 
+* There are two ways users can authenticate to Exchange Online:
+* 1. App access:
+*     Follow https://learn.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps to create an app        registration to be used for this script.
+*     The API permissions required are: 'Reports.Read.All', 'User.Read.All', and 'Group.Read.All' from Microsoft Graph and `Exchange.ManageAsApp` from Office 365 Exchange Online.
+*     To run this script successfully, you will need:
+	    a. Tenant ID.
+	    b. Client ID (App ID) of the app created above.
+	    c. Client Secret created on the app above.
+
+* 2. User access:
+*     Login through the admin user account when prompted on the browser.
+
 
 ## Installation
 


### PR DESCRIPTION
The current script uses admin user access to login to exchange powershell to run commands.
Adding a new access method to login using application credentials with this PR.

Tested on a sandbox subscription.
1. Incorrect option selection:
<img width="780" alt="Screenshot 2024-12-09 at 1 03 34 PM" src="https://github.com/user-attachments/assets/5ed4227a-1f80-4a94-94b3-637c46a5b324">

2. User access (login through the user account on browser):
<img width="899" alt="Screenshot 2024-12-09 at 1 05 07 PM" src="https://github.com/user-attachments/assets/df42a15b-1821-4c84-a4cf-0d77f42038f0">

3. App access:
<img width="1705" alt="Screenshot 2024-12-09 at 1 08 01 PM" src="https://github.com/user-attachments/assets/50309a5d-7dce-43ca-acfb-aa239979a03f">
